### PR TITLE
Do not run the Test CI for PRs marked as draft

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [devel, main, master, wip]
   pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_call:
 
 env:
@@ -11,6 +12,7 @@ env:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     name: test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -19,13 +21,13 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.11
+    - uses: actions/setup-python@v6
+      with:
+        python-version: 3.13
   
     - name: install requirements
       run: python -m pip install nox pre-commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,10 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
       with:
-        python-version: 3.11
+        python-version: 3.12
     - uses: actions/setup-python@v6
       with:
-        python-version: 3.13
+        python-version: 3.14
   
     - name: install requirements
       run: python -m pip install nox pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/myint/autoflake
-    rev: v2.3.1
+    rev: v2.3.3
     hooks:
     - id: autoflake
       args: ["--in-place",  "--imports=fillname", "--ignore-init-module-imports", "--remove-unused-variables"]
@@ -14,13 +14,13 @@ repos:
       exclude: ^.github/
 
   - repo: https://github.com/pycqa/isort
-    rev: 7.0.0
+    rev: 9.0.0a3
     hooks:
       - id: isort
         exclude: ^.github/
 
   - repo: https://github.com/psf/black
-    rev: 25.9.0
+    rev: 26.3.1
     hooks:
     - id: black
       exclude: ^.github/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,19 +2,25 @@ repos:
   - repo: https://github.com/myint/autoflake
     rev: v2.3.3
     hooks:
-    - id: autoflake
-      args: ["--in-place",  "--imports=fillname", "--ignore-init-module-imports", "--remove-unused-variables"]
-      exclude: ^.github/
+      - id: autoflake
+        args:
+          [
+            "--in-place",
+            "--imports=fillname",
+            "--ignore-init-module-imports",
+            "--remove-unused-variables",
+          ]
+        exclude: ^.github/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-    - id: end-of-file-fixer
-    - id: trailing-whitespace
-      exclude: ^.github/
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        exclude: ^.github/
 
   - repo: https://github.com/pycqa/isort
-    rev: 9.0.0a3
+    rev: 8.0.0
     hooks:
       - id: isort
         exclude: ^.github/
@@ -22,14 +28,14 @@ repos:
   - repo: https://github.com/psf/black
     rev: 26.3.1
     hooks:
-    - id: black
-      exclude: ^.github/
+      - id: black
+        exclude: ^.github/
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 1.0.0
     hooks:
-    - id: mdformat
-      args: ["--wrap", "79"]
-      exclude: ^docs/
-      additional_dependencies:
-      - mdformat-gfm
+      - id: mdformat
+        args: [ "--wrap", "79" ]
+        exclude: ^docs/
+        additional_dependencies:
+          - mdformat-gfm

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ nox.options.sessions = "lint_pylint", "typecheck", "test"
 EDITABLE_TESTS = True
 PYTHON_VERSIONS = None
 if "GITHUB_ACTIONS" in os.environ:
-    PYTHON_VERSIONS = ["3.11", "3.13"]
+    PYTHON_VERSIONS = ["3.12", "3.14"]
     EDITABLE_TESTS = False
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ nox.options.sessions = "lint_pylint", "typecheck", "test"
 EDITABLE_TESTS = True
 PYTHON_VERSIONS = None
 if "GITHUB_ACTIONS" in os.environ:
-    PYTHON_VERSIONS = ["3.9", "3.11"]
+    PYTHON_VERSIONS = ["3.11", "3.13"]
     EDITABLE_TESTS = False
 
 

--- a/src/fillname/utils/parser.py
+++ b/src/fillname/utils/parser.py
@@ -20,12 +20,10 @@ def get_parser() -> ArgumentParser:
     """
     parser = ArgumentParser(
         prog="fillname",
-        description=dedent(
-            """\
+        description=dedent("""\
             fillname
             filldescription
-            """
-        ),
+            """),
     )
     levels = [
         ("error", logging.ERROR),


### PR DESCRIPTION
This is a suggestion to reduce the number of times the Test CI is run.
In my opinion in early stages of a PR it's not necessary to run the CI for every push.
I did some googling to get the correct code but maybe there are still ways to improve this.

I also used this to updated some dependencies and increase the default Python versions for testing but I am open to other suggestions. Not sure what the (dis-)advantages of each version currently are...